### PR TITLE
add fields that need to be interpreted as templates

### DIFF
--- a/operators/download_csv_from_db_operator.py
+++ b/operators/download_csv_from_db_operator.py
@@ -24,6 +24,7 @@ from airflow.utils.decorators import apply_defaults
 class DownloadCSVFromDbOperator(BaseOperator):
     ui_color = '#95aad5'
     ui_fgcolor = '#000000'
+    template_fields = ('select_sql', 'target_file_dir', 'file_name')
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION
Estes campos precisam ser interpretados como templates para, por exemplo, poder usar a variável `execution_date` no Airflow.