### PR TITLE
Adiciona a coluna columns_to_ignore de volta no Operador

### DIFF
--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -30,6 +30,7 @@ class DbToDbHook(BaseHook):
     def full_copy(self,
              destination_table: str,
              select_sql: str = None,
+             columns_to_ignore: list = [],
              destination_truncate: str = True,
              source_table: str = None,
              chunksize: int = 1000):
@@ -41,6 +42,7 @@ class DbToDbHook(BaseHook):
             destination_conn_id=self.destination_conn_id,
             destination_provider=self.destination_provider,
             select_sql=select_sql,
+            columns_to_ignore=columns_to_ignore,
             destination_truncate=destination_truncate,
             chunksize=chunksize
             )

--- a/operators/copy_db_to_db_operator.py
+++ b/operators/copy_db_to_db_operator.py
@@ -33,6 +33,7 @@ class CopyDbToDbOperator(BaseOperator):
             destination_provider: str,
             source_table: str = None,
             select_sql: str = None,
+            columns_to_ignore: list = [],
             destination_truncate: bool = True,
             chunksize: int = 1000,
             *args, **kwargs) -> None:
@@ -44,6 +45,7 @@ class CopyDbToDbOperator(BaseOperator):
         self.destination_provider = destination_provider
         self.source_table = source_table
         self.select_sql = select_sql
+        self.columns_to_ignore = columns_to_ignore
         self.destination_truncate = destination_truncate
         self.chunksize = chunksize
 
@@ -59,6 +61,7 @@ class CopyDbToDbOperator(BaseOperator):
             destination_table=self.destination_table,
             source_table=self.source_table,
             select_sql=self.select_sql,
+            columns_to_ignore=self.columns_to_ignore,
             destination_truncate=self.destination_truncate,
             chunksize=self.chunksize
             )


### PR DESCRIPTION
Esta correção devolve ao CopyDbToDbOperator o parâmetro `columns_to_ignore` que havia sido removido durante a refatoração para criação do operator.