### PR TITLE
Adapta os imports para nova convenção incluindo o nome do projeto

### DIFF
--- a/custom_functions/samba_services.py
+++ b/custom_functions/samba_services.py
@@ -13,7 +13,7 @@ from smb.SMBConnection import SMBConnection
 
 from airflow.hooks.base_hook import BaseHook
 
-from custom_functions.utils.string_formatting import slugify_column_names
+from FastETL.custom_functions.utils.string_formatting import slugify_column_names
 
 class SambaConnection():
     """

--- a/hooks/bacen_STA_hook.py
+++ b/hooks/bacen_STA_hook.py
@@ -18,7 +18,7 @@ from airflow.utils.email import send_email
 from airflow.utils.decorators import apply_defaults
 from airflow.hooks.base_hook import BaseHook
 
-from custom_functions.utils.encode_html import replace_to_html_encode
+from FastETL.custom_functions.utils.encode_html import replace_to_html_encode
 
 class BacenSTAHook(BaseHook):
     DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"

--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -10,7 +10,7 @@ from airflow.utils.email import send_email
 from airflow.utils.decorators import apply_defaults
 from airflow.hooks.base_hook import BaseHook
 
-from custom_functions.fast_etl import copy_db_to_db
+from FastETL.custom_functions.fast_etl import copy_db_to_db
 
 class DbToDbHook(BaseHook):
 

--- a/hooks/gsheet_hook.py
+++ b/hooks/gsheet_hook.py
@@ -16,8 +16,8 @@ from apiclient import discovery
 from httplib2 import Http
 import pygsheets
 
-from custom_functions.utils.string_formatting import slugify_column_names
-from custom_functions.utils.string_formatting import convert_gsheets_str_to_datetime
+from FastETL.custom_functions.utils.string_formatting import slugify_column_names
+from FastETL.custom_functions.utils.string_formatting import convert_gsheets_str_to_datetime
 
 class GSheetHook(BaseHook):
 

--- a/operators/copy_db_to_db_operator.py
+++ b/operators/copy_db_to_db_operator.py
@@ -19,7 +19,7 @@ Args:
 from airflow.models.baseoperator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from hooks.db_to_db_hook import DbToDbHook
+from FastETL.hooks.db_to_db_hook import DbToDbHook
 
 class CopyDbToDbOperator(BaseOperator):
 

--- a/operators/load_gsheet_operator.py
+++ b/operators/load_gsheet_operator.py
@@ -24,8 +24,8 @@ Args:
 from airflow.operators.bash_operator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from hooks.gsheet_hook import GSheetHook
-from custom_functions.fast_etl import get_mssql_odbc_engine
+from FastETL.hooks.gsheet_hook import GSheetHook
+from FastETL.custom_functions.fast_etl import get_mssql_odbc_engine
 
 class LoadGSheetOperator(BaseOperator):
     ui_color = '#72efdd'


### PR DESCRIPTION
Esta modificação possibita o uso de outros pacotes de plugins além do FastETL. Para isso o projeto deverá ser clonado em um diretório específico dentro do diretório `/plugins` do Airflow: `/plugins/FastETL/`

Além desta mudança, o ambiente local do Airflow utilizado na SEGES, o  [**airflow-docker-local**](https://git.economia.gov.br/seges-cginf/airflow-docker-local), foi adaptado para mapear corretamente o volume do FastETL.