### PR TITLE
add templating to field select_sql in CopyDbToDbOperator

### DIFF
--- a/operators/copy_db_to_db_operator.py
+++ b/operators/copy_db_to_db_operator.py
@@ -22,6 +22,7 @@ from airflow.utils.decorators import apply_defaults
 from FastETL.hooks.db_to_db_hook import DbToDbHook
 
 class CopyDbToDbOperator(BaseOperator):
+    template_fields = ('select_sql', )
 
     @apply_defaults
     def __init__(


### PR DESCRIPTION
O CopyDbToDbOperator não está aceitando usar templates Jinja do Airflow no parâmetro de inicialização `select_sql`. Este PR corrige isto.