### PR TITLE
return the file name to provide metadata for TaskFlow

### DIFF
--- a/operators/download_csv_from_db_operator.py
+++ b/operators/download_csv_from_db_operator.py
@@ -68,3 +68,4 @@ class DownloadCSVFromDbOperator(BaseOperator):
 
         file_path = os.path.join(self.target_file_dir, self.file_name)
         df.to_csv(file_path, index=False)
+        return self.file_name


### PR DESCRIPTION
O TaskFlow determina a ordem das tasks pelos valores retornados via XCom e reutilizados. Assim, seria bom todo operador retornar algum metadado que possa ser utilizado pelas tasks seguintes.