### PR TITLE
Remove colunas antes de gerar o CSV

### DIFF
--- a/operators/download_csv_from_db_operator.py
+++ b/operators/download_csv_from_db_operator.py
@@ -94,6 +94,13 @@ class DownloadCSVFromDbOperator(BaseOperator):
             for col in self.int_columns:
                 df[col] = df[col].astype("Int64")
 
+        # Remove specified columns
+        if self.columns_to_remove:
+            df.drop(self.columns_to_remove,
+                    axis=1,
+                    errors='ignore',
+                    inplace=True)
+
         # Create folder if not exists
         if not os.path.exists(self.target_file_dir):
             os.mkdir(self.target_file_dir)

--- a/operators/download_csv_from_db_operator.py
+++ b/operators/download_csv_from_db_operator.py
@@ -81,10 +81,13 @@ class DownloadCSVFromDbOperator(BaseOperator):
         else:
             raise Exception('Conn_type not implemented.')
 
-        df = db_hook.get_pandas_df(
-            self.select_sql if self.select_sql
-            else self.select_all_sql()
-            )
+        if self.select_sql:
+            df_select = self.select_sql
+        else:
+            df_select = self.select_all_sql()
+
+        self.log.info(f'Executing SQL check: {df_select}')
+        df = db_hook.get_pandas_df(df_select)
 
         # Convert columns data types to int
         if self.int_columns:


### PR DESCRIPTION
A coluna `columns_to_ignore` já era utilizada para remover colunas da query SQL gerada quando o operador é utilizado para download de um tabela inteira, e não utilizando o parâmetro `select_sql`.