### PR TITLE
add function to convert indented markdown to html

### DIFF
--- a/custom_functions/utils/markdown_html.py
+++ b/custom_functions/utils/markdown_html.py
@@ -1,9 +1,0 @@
-import inspect
-import textwrap
-
-from markdown import markdown
-
-def imarkdown_to_html(text: str) -> str:
-    """Transforms indented markdown text to html.
-    """
-    return markdown(inspect.cleandoc(textwrap.dedent(text)))

--- a/custom_functions/utils/markdown_html.py
+++ b/custom_functions/utils/markdown_html.py
@@ -1,0 +1,9 @@
+import inspect
+import textwrap
+
+from markdown import markdown
+
+def imarkdown_to_html(text: str) -> str:
+    """Transforms indented markdown text to html.
+    """
+    return markdown(inspect.cleandoc(textwrap.dedent(text)))

--- a/custom_functions/utils/string_formatting.py
+++ b/custom_functions/utils/string_formatting.py
@@ -4,7 +4,11 @@ DAGs
 """
 
 from datetime import datetime
+import inspect
+import textwrap
+
 import slugify as sl
+from markdown import markdown
 
 def slugify_column_names(column_name: str):
     """
@@ -58,3 +62,8 @@ def construct_vocative_names_from_emails(emails_list: list):
         vocative_names = captalized_names_list[0]
 
     return vocative_names
+
+def imarkdown_to_html(text: str) -> str:
+    """Transforms indented markdown text to html.
+    """
+    return markdown(inspect.cleandoc(textwrap.dedent(text)))


### PR DESCRIPTION
Possibilita usar texto indentado em multiline string, escrito em markdown, e convertê-lo para html.

Exemplo de como usar:

```python
from FastETL.custom_functions.utils.markdown_html import imarkdown_to_html

@task()
def transform_markdown():
    text = """
    ## A big heading

    This is a paragraph.

    * item 1
    * item 2
    * item 3
    """

    return imarkdown_to_html(text)
```