### PR TITLE
Remove quotations on query for mysql

### DIFF
--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -413,6 +413,10 @@ def copy_db_to_db(destination_table: str,
                     if not select_sql:
                         select_sql = build_select_sql(source_table, col_list)
 
+                    # Remove as aspas na query para compatibilidade com o MYSQL
+                    if source_provider == 'MYSQL':
+                       select_sql = select_sql.replace('"', '')
+
                     # truncate stg
                     if destination_truncate:
                         destination_cur.execute(truncate)


### PR DESCRIPTION
In the copy_db_to_db function, remove quotations in insert queries, providing compatibilty for mysql.

Related to Issue #54 