### PR TITLE
Cria um novo módulo de configurações

### DIFF
--- a/custom_functions/config.py
+++ b/custom_functions/config.py
@@ -1,0 +1,4 @@
+"""Configuration used by other modules.
+"""
+
+USER_AGENT = "airflow-fastetl/0.1 (+https://github.com/economiagovbr/FastETL)"

--- a/hooks/ckan_hook.py
+++ b/hooks/ckan_hook.py
@@ -8,7 +8,7 @@ from airflow.hooks.base_hook import BaseHook
 
 from ckanapi import RemoteCKAN
 
-USER_AGENT = "airflow-fastetl/0.1 (+https://github.com/economiagovbr/FastETL)"
+from FastETL.custom_functions.config import USER_AGENT
 
 class CKANHook(BaseHook):
     """Provides access to the CKAN API.


### PR DESCRIPTION
Constantes e configurações comuns a todos os módulos deveriam ser importadas de um módulo comum, em vez de repetidas em vários módulos diferentes.

Propomos aqui criar o módulo `custom_functions/config.py`. Por exemplo, para usar a configuração `USER_AGENT`, importamos assim:

```python
from FastETL.custom_functions.config import USER_AGENT
```