### PR TITLE
Cria o hook para o Open Street Routing Machine (OSRM)

### DIFF
--- a/custom_functions/config.py
+++ b/custom_functions/config.py
@@ -1,0 +1,4 @@
+"""Configuration used by other modules.
+"""
+
+USER_AGENT = "airflow-fastetl/0.1 (+https://github.com/economiagovbr/FastETL)"

--- a/hooks/ckan_hook.py
+++ b/hooks/ckan_hook.py
@@ -8,7 +8,7 @@ from airflow.hooks.base_hook import BaseHook
 
 from ckanapi import RemoteCKAN
 
-USER_AGENT = "airflow-fastetl/0.1 (+https://github.com/economiagovbr/FastETL)"
+from FastETL.custom_functions.config import USER_AGENT
 
 class CKANHook(BaseHook):
     """Provides access to the CKAN API.

--- a/hooks/osrm_hook.py
+++ b/hooks/osrm_hook.py
@@ -1,0 +1,67 @@
+"""Airflow hooks to access the OSRM API to calculate routes and
+distances.
+"""
+import urllib
+import requests
+from functools import cached_property
+from typing import Tuple
+
+from airflow.utils.decorators import apply_defaults
+from airflow.hooks.base_hook import BaseHook
+
+from FastETL.custom_functions.config import USER_AGENT
+
+class OSRMHook(BaseHook):
+    """Provides access to the Open Street Routing Machine (OSRM) API.
+    """
+
+    @apply_defaults
+    def __init__(self,
+        conn_id: str,
+        *args,
+        **kwargs
+        ):
+        super().__init__(*args, **kwargs)
+        self.conn_id = conn_id
+
+    @cached_property
+    def api_endpoint(self):
+        """Gets the API endpoint from the Airflow connection.
+        """
+        conn = BaseHook.get_connection(self.conn_id)
+        osrm_url = f"{conn.schema}://{conn.host}"
+        if getattr(conn, "port", None):
+            osrm_url += f":{conn.port}"
+        return osrm_url
+
+    def get_route(self,
+        origin: Tuple[float, float],
+        destination: Tuple[float, float],
+        profile: str = 'driving') -> dict:
+        """Gets the calculated routes from the OSRM API from the defined
+        origin and destination point, using the specified profile.
+        """
+        lat_o, long_o = origin
+        lat_d, long_d = destination
+        url = urllib.parse.urljoin(
+            self.api_endpoint,
+            f'/route/v1/{profile}/{long_o},{lat_o};{long_d},{lat_d}'
+        )
+
+        response = requests.get(
+            url,
+            params={'steps': 'true'}
+        )
+
+        if response.status_code != requests.codes.ok:
+            raise ValueError(f'OSRM API returned code {response.status_code}.')
+
+        return response.json()
+
+    @staticmethod
+    def get_shortest_distance(data: dict) -> float:
+        """Gets the distance of the shortest route using the OSRM API.
+        """
+        if data['code'] == 'Ok':
+            return data['routes'][0]['distance'] / 1000.0
+        return None


### PR DESCRIPTION
Para poder facilitar a reutilização, proponho incluir este hook no FastETL para poder ser reutilziado em várias DAGs.

A configuração do endpoint (schema, host, port) do OSRM fica em uma conexão do Airflow.

![osrm-airflow](https://user-images.githubusercontent.com/1058414/169057658-1385c59d-9521-472b-b399-68a305df5fce.png)

