### PR TITLE
Fix BaseHook import

### DIFF
--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -31,7 +31,7 @@ from airflow.hooks.postgres_hook import PostgresHook
 from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.providers.odbc.hooks.odbc import OdbcHook
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.hooks.dbapi import DbApiHook
 
 

--- a/custom_functions/samba_services.py
+++ b/custom_functions/samba_services.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 import pandas as pd
 from smb.SMBConnection import SMBConnection
 
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from FastETL.custom_functions.utils.string_formatting import slugify_column_names
 

--- a/hooks/bacen_STA_hook.py
+++ b/hooks/bacen_STA_hook.py
@@ -16,7 +16,7 @@ from airflow import settings
 from airflow.models import Connection
 from airflow.utils.email import send_email
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from FastETL.custom_functions.utils.encode_html import replace_to_html_encode
 

--- a/hooks/ckan_hook.py
+++ b/hooks/ckan_hook.py
@@ -4,7 +4,7 @@
 from collections import ChainMap
 
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from ckanapi import RemoteCKAN
 

--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -8,7 +8,7 @@ from airflow import settings
 from airflow.models import Connection
 from airflow.utils.email import send_email
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from FastETL.custom_functions.fast_etl import copy_db_to_db
 

--- a/hooks/dou_hook.py
+++ b/hooks/dou_hook.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from bs4 import BeautifulSoup
 

--- a/hooks/gsheet_hook.py
+++ b/hooks/gsheet_hook.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from airflow import AirflowException
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from oauth2client.service_account import ServiceAccountCredentials
 from apiclient import discovery

--- a/hooks/osrm_hook.py
+++ b/hooks/osrm_hook.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from typing import Tuple
 
 from airflow.utils.decorators import apply_defaults
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 from FastETL.custom_functions.config import USER_AGENT
 

--- a/operators/check_de_para_operator.py
+++ b/operators/check_de_para_operator.py
@@ -12,7 +12,7 @@ guilty: Vitor.
 # [ ] Mudar operador nas DAGs
 
 from airflow.exceptions import AirflowException
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.models.baseoperator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/operators/download_csv_from_db_operator.py
+++ b/operators/download_csv_from_db_operator.py
@@ -27,7 +27,7 @@ import os
 from airflow.models.baseoperator import BaseOperator
 from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.hooks.postgres_hook import PostgresHook
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.utils.decorators import apply_defaults
 
 from FastETL.custom_functions.fast_etl import get_table_cols_name


### PR DESCRIPTION
as airflow.hooks.base_hook has been deprecated, we import [BaseHook](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/hooks/base/index.html#airflow.hooks.base.BaseHook) now from `airflow.hooks.base`.