### PR TITLE
Retorna None se a rota não puder ser calculada

### DIFF
--- a/hooks/osrm_hook.py
+++ b/hooks/osrm_hook.py
@@ -106,5 +106,10 @@ def get_shortest_distance(data: dict) -> float:
             route.
     """
     if data['code'] == 'Ok':
-        return data['routes'][0]['distance'] / 1000.0
+        if (
+            len(data['routes']) > 0  # has at least one route
+            and data['routes'][0].get('geometry', None) is not None
+            and data['routes'][0]['distance'] > 0
+        ):
+            return data['routes'][0]['distance'] / 1000.0
     return None

--- a/operators/osrm_distance_operator.py
+++ b/operators/osrm_distance_operator.py
@@ -190,7 +190,7 @@ class OSRMDistanceDbOperator(BaseOperator):
                     origin=(origin_latitude, origin_longitude),
                     destination=(destination_latitude, destination_longitude)
                 )
-            )
+            ) or 'NULL' # use NULL if the function returns None
         )
 
     def execute(self, context: dict):


### PR DESCRIPTION
como, por exemplo, se o OSRM não dispuser dos mapas para as coordenadas informadas, ou não existir rota entre os pontos.

- fix #77