### PR TITLE
Check data_column field type

### DIFF
--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -520,6 +520,10 @@ def _build_filter_condition(dest_hook: MsSqlHook,
         key_column (str): nome da coluna a ser utilizado como chave na
         etapa de atualização dos registros antigos que sofreram
         atualizações na origem.
+        
+        Returns:
+                Tuple[str, str]: Tupla contendo o valor máximo e a condição
+                        where da query sql.
 
     """
     if date_column:

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -500,7 +500,7 @@ def _build_increm_filter(col_list: list, dest_hook: MsSqlHook,
 
 
 def _build_filter_condition(dest_hook: MsSqlHook,
-                table: str, date_column: str, key_column: str) -> str:
+                table: str, date_column: str, key_column: str) -> Tuple[str, str]:
     """Monta o filtro (where) obtenção o valor max() da tabela,
     distinguindo se a coluna é a "data ou data/hora de atualização"
     (date_column) ou outro número sequencial (key_column), por exemplo

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -498,12 +498,30 @@ def _build_increm_filter(col_list: list, dest_hook: MsSqlHook,
     return where_condition
 
 
-# New func: Distingue se a coluna para obtenção do max() e montagem do
-#           filtro (where) é uma "data/hora alteração" ou é um número
-#           sequencial (id, pk, etc): 'date_column' ou 'key_column'.
-def _build_filter_condition(dest_hook: MsSqlHook,
-                table: str, date_column: str, key_column: str):
 
+def _build_filter_condition(dest_hook: MsSqlHook,
+                table: str, date_column: str, key_column: str) -> str:
+    """Monta o filtro (where) obtenção o valor max() da tabela,
+    distinguindo se a coluna é a "data ou data/hora de atualização"
+    (date_column) ou outro número sequencial (key_column), por exemplo
+    id, pk, etc.
+
+    Exemplo:
+        _build_filter_condition(dest_hook: hook,
+                        table=table,
+                        date_column=date_column,
+                        key_column=key_column)
+        
+    Args:
+        dest_hook (str): hook de conexão do DB de destino
+        table (str): tabela a ser sincronizada
+        date_column (str): nome da coluna a ser utilizado para
+        identificação dos registros atualizados.
+        key_column (str): nome da coluna a ser utilizado como chave na
+        etapa de atualização dos registros antigos que sofreram
+        atualizações na origem.
+
+    """
     if date_column:
         sql = f"SELECT MAX({date_column}) FROM {table}"
     else:

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -10,7 +10,7 @@ import time
 from datetime import datetime, date
 import warnings
 import urllib
-from typing import List, Union
+from typing import List, Union, Tuple
 import pyodbc
 import ctds
 import ctds.pool

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -7,7 +7,7 @@ guilty: Vitor Bellini, Nitai Bezerra
 """
 
 import time
-from datetime import datetime
+from datetime import datetime, date
 import warnings
 import urllib
 from typing import List, Union
@@ -512,7 +512,12 @@ def _build_filter_condition(dest_hook: MsSqlHook,
     max_value = dest_hook.get_first(sql)[0]
 
     if date_column:
-        max_value = max_value.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        # Verifica se o formato do campo max_value é date ou datetime
+        if (type(max_value) == date):
+            max_value = max_value.strftime("%Y-%m-%d")
+        elif (type(max_value) == datetime):
+            max_value = max_value.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        
         where_condition = f"{date_column} > '{max_value}'"
     else:
         max_value = str(max_value)


### PR DESCRIPTION
On incremental table synchronization, checks if date_column type is date or datetime before building the select SQL statement to compare the tables from distinctive sources.