### PR TITLE
Fix extra spaces in templated reference_date

### DIFF
--- a/custom_functions/utils/date.py
+++ b/custom_functions/utils/date.py
@@ -111,7 +111,7 @@ base_template_reference_date = '''
         {% set the_date = execution_date %}
     {% endif %}
 {% endif %}
-'''.replace('\n', '')
+'''
 
 # para ser usado em dags
 template_reference_date = remove_template_indentation(


### PR DESCRIPTION
The `replace('\n', '')` was interfering with `remove_template_indentation`, which left extra spaces in between the template logic.