### PR TITLE
Add functions to copy table comments between databases

### DIFF
--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -42,6 +42,8 @@ class DbConnection:
 
     def __init__(self, conn_id: str, provider: str):
         # Valida providers suportados
+        providers = ["MSSQL", "PG", "POSTGRES", "MYSQL"]
+        provider = provider.upper()
         assert provider in providers, (
             "Provider não suportado " "(utilize MSSQL, PG ou MYSQL) :P"
         )
@@ -262,12 +264,12 @@ def compare_source_dest_rows(
 
 
 def get_hook_and_engine_by_provider(provider: str, conn_id: str) -> [DbApiHook, Engine]:
-        provider: str,
-        conn_id: str) -> [DbApiHook, Engine]:
+    provider = provider.upper()
+
     if provider == "MSSQL":
         hook = MsSqlHook(conn_id)
         engine = get_mssql_odbc_engine(conn_id)
-    elif provider == 'PG':
+    elif provider == "PG" or provider == "POSTGRES":
         hook = PostgresHook(conn_id)
         engine = hook.get_sqlalchemy_engine()
     elif provider == "MYSQL":

--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -33,7 +33,8 @@ class DbToDbHook(BaseHook):
              columns_to_ignore: list = [],
              destination_truncate: str = True,
              source_table: str = None,
-             chunksize: int = 1000):
+             chunksize: int = 1000,
+             copy_table_comments: bool = False):
         copy_db_to_db(
             source_table=source_table,
             destination_table=destination_table,
@@ -44,5 +45,6 @@ class DbToDbHook(BaseHook):
             select_sql=select_sql,
             columns_to_ignore=columns_to_ignore,
             destination_truncate=destination_truncate,
-            chunksize=chunksize
+            chunksize=chunksize,
+            copy_table_comments=copy_table_comments
             )

--- a/operators/copy_db_to_db_operator.py
+++ b/operators/copy_db_to_db_operator.py
@@ -37,6 +37,7 @@ class CopyDbToDbOperator(BaseOperator):
             columns_to_ignore: list = [],
             destination_truncate: bool = True,
             chunksize: int = 1000,
+            copy_table_comments: bool = False,
             *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.destination_table = destination_table
@@ -49,6 +50,7 @@ class CopyDbToDbOperator(BaseOperator):
         self.columns_to_ignore = columns_to_ignore
         self.destination_truncate = destination_truncate
         self.chunksize = chunksize
+        self.copy_table_comments = copy_table_comments
 
 
     def execute(self, context):
@@ -64,5 +66,6 @@ class CopyDbToDbOperator(BaseOperator):
             select_sql=self.select_sql,
             columns_to_ignore=self.columns_to_ignore,
             destination_truncate=self.destination_truncate,
-            chunksize=self.chunksize
+            chunksize=self.chunksize,
+            copy_table_comments=self.copy_table_comments
             )


### PR DESCRIPTION
In this change:
* apply black formatter to file fast_etl.py
* minor db type check update
* add functions to copy table and columns comments between databases