### PR TITLE
Do not cast `nivel_erro` column to str

### DIFF
--- a/custom_functions/patchwork.py
+++ b/custom_functions/patchwork.py
@@ -1184,7 +1184,7 @@ def merge_patches(tmp_dir: str, source: str, source_config: dict,
         df_qa = DataPatch.read_zipped_csv(qa_file_name)
         # linhas a remover neste arquivo de QA
         exclude_by_qa = (
-            df_qa[df_qa.nivel_erro == str(QALogLevel.DROP_LINE.value)]
+            df_qa[df_qa.nivel_erro == QALogLevel.DROP_LINE.value]
             ['primary_keys_values']
             .str.split(',', expand=True)
         )


### PR DESCRIPTION
This will use the `nivel_erro` column as is (dtype `int64`), without casting to `str`.

The cast was in place probably because in a previous version we did not use data packages for the QA file and when the csv file was read the column would receive the `str` type. As a result, lines dropped by the QA process were not actually being dropped.

closes #132