### PR TITLE
Source dest connection

### DIFF
--- a/custom_functions/copy_db_extensions.py
+++ b/custom_functions/copy_db_extensions.py
@@ -93,7 +93,9 @@ def copy_by_key_interval(
                     insert, truncate = build_dest_sqls(
                         destination_table, col_list, wildcard_symbol
                     )
-                    select_sql = build_select_sql(source_table, col_list)
+                    select_sql = build_select_sql(schema=source_table.split(".")[0],
+                                                  table=source_table.split(".")[1],
+                                                  column_list=col_list)
                     # pyodbc: select_sql = f"{select_sql} WHERE {key_column} BETWEEN ? AND ?"
                     select_sql = f"{select_sql} WHERE {key_column} BETWEEN %s AND %s"
 
@@ -320,7 +322,9 @@ def copy_by_limit_offset(
                         table=destination_table.split(".")[1],
                     )
                     insert, truncate = build_dest_sqls(destination_table, col_list, "?")
-                    select_sql = build_select_sql(source_table, col_list)
+                    select_sql = build_select_sql(schema=source_table.split(".")[0],
+                                                  table=source_table.split(".")[1],
+                                                  column_list=col_list)
                     # pyodbc: select_sql = f"{select_sql} limit ?, ?"
                     select_sql = f"{select_sql} limit %s, %s"
 

--- a/custom_functions/copy_db_extensions.py
+++ b/custom_functions/copy_db_extensions.py
@@ -11,7 +11,6 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 from FastETL.custom_functions.utils.db_connection import DbConnection, get_conn_type
 from FastETL.custom_functions.utils.get_table_cols_name import get_table_cols_name
 from FastETL.custom_functions.fast_etl import (
-    validate_db_string,
     build_dest_sqls,
     build_select_sql,
 )
@@ -66,9 +65,6 @@ def copy_by_key_interval(
         * try/except nas aberturas das conexões; se erro: return False, key_start
         * comparar performance do prepared statement no source: psycopg2 x pyodbc
     """
-
-    # validate db string
-    validate_db_string(source_table, destination_table, None)
 
     # create connections
     with DbConnection(source_conn_id) as source_conn:
@@ -302,9 +298,6 @@ def copy_by_limit_offset(
         destination_truncate (bool): booleano para truncar tabela de destino
             antes do load. Default = True
     """
-
-    # validate db string
-    validate_db_string(source_table, destination_table, None)
 
     # create connections
     with DbConnection(source_conn_id) as source_conn:

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -218,7 +218,9 @@ def create_table_if_not_exists(
         destination.conn_id
     )
     try:
-        destination_hook.get_pandas_df(f"select * from {destination.table} where 1=2")
+        destination_hook.get_pandas_df(
+            f"select * from {destination.schema}.{destination.table} where 1=2"
+        )
     except (DatabaseError, OperationalError, NoSuchModuleError) as db_error:
         if not ERROR_TABLE_DOES_NOT_EXIST[destination_provider] in str(db_error):
             raise db_error
@@ -464,7 +466,7 @@ def copy_db_to_db(
                         select_sql = build_select_sql(
                             schema=source.schema,
                             table=source.table,
-                            column_list=col_list
+                            column_list=col_list,
                         )
 
                     # Remove as aspas na query para compatibilidade com o MYSQL

--- a/custom_functions/fast_etl.py
+++ b/custom_functions/fast_etl.py
@@ -295,8 +295,8 @@ def get_schema_table_from_query(query: str) -> str:
 
 
 def copy_db_to_db(
-    source_conn: Dict[str, str],
-    destination_conn: Dict[str, str],
+    source: Dict[str, str],
+    destination: Dict[str, str],
     columns_to_ignore: list = None,
     destination_truncate: bool = True,
     chunksize: int = 1000,
@@ -358,8 +358,8 @@ def copy_db_to_db(
     # dest_schema_table = f"{destination_conn['schema']}.{destination_conn['table']}"
 
     # validate connections
-    source = SourceConnection(**source_conn)
-    destination = DestinationConnection(**destination_conn)
+    source = SourceConnection(**source)
+    destination = DestinationConnection(**destination)
 
     # create table if not exists in destination db
     create_table_if_not_exists(
@@ -664,13 +664,13 @@ def sync_db_2_db(
     logging.info("SELECT para espelhamento: %s", select_diff)
 
     copy_db_to_db(
-        source_conn={
+        source={
             "conn_id": source_conn_id,
             "query": select_diff,
             "schema": source_table_name.split(".")[0],
             "table": source_table_name.split(".")[1],
         },
-        destination_conn={
+        destination={
             "conn_id": destination_conn_id,
             "schema": inc_table_name.split(".")[0],
             "table": inc_table_name.split(".")[1],

--- a/custom_functions/utils/get_table_cols_name.py
+++ b/custom_functions/utils/get_table_cols_name.py
@@ -8,7 +8,7 @@ from FastETL.custom_functions.utils.db_connection import DbConnection
 
 
 def get_table_cols_name(
-    conn_id: str, schema: str, table: str, columns_to_ignore: List = []
+    conn_id: str, schema: str, table: str, columns_to_ignore: List = None
 ) -> List[str]:
     """
     Obtem a lista de colunas de uma tabela.
@@ -19,6 +19,7 @@ def get_table_cols_name(
             cur.execute(f"SELECT * FROM {schema}.{table} WHERE 1=2")
             column_names = [tup[0] for tup in cur.description]
 
-    column_names = [n for n in column_names if n not in columns_to_ignore]
+    if columns_to_ignore:
+        column_names = [n for n in column_names if n not in columns_to_ignore]
 
     return column_names

--- a/custom_functions/utils/load_info.py
+++ b/custom_functions/utils/load_info.py
@@ -16,10 +16,11 @@ class LoadInfo:
     def __init__(
         self,
         source_conn_id: str,
-        source_schema_table: str,
+        source_table: str,
         load_type: str,
         dest_conn_id: str,
         log_schema_name: str,
+        source_schema: str = "não informado",
         log_table_name: str = "consumo_dados",
     ) -> None:
         """Initialize LoadInfo class variables.
@@ -35,13 +36,8 @@ class LoadInfo:
         """
 
         self.s_conn_id = source_conn_id
-
-        try:
-            self.s_schema, self.s_table = source_schema_table.split(".")
-        except ValueError:
-            logging.warning("Tabela de origem sem especificação na query.")
-            self.s_schema, self.s_table = "não informado", source_schema_table
-
+        self.s_schema = source_schema
+        self.s_table = source_table
         self.load_type = load_type
         s_conn_values = BaseHook.get_connection(source_conn_id)
         self.s_conn_database = s_conn_values.schema

--- a/custom_functions/utils/table_comments.py
+++ b/custom_functions/utils/table_comments.py
@@ -23,16 +23,18 @@ class TableComments:
     And accepts to the destination mssql and postgres.
     """
 
-    def __init__(self, conn_id: str, schema_table: str):
+    def __init__(self, conn_id: str, schema: str, table: str):
         """Initialize TableComments class variables.
 
         Args:
             conn_id (str): Airflow connection id
-            schema_table (str): Table str at format schema.table
+            schema (str): Schema str
+            table (str): Table str
         """
 
         self.conn_id = conn_id
-        self.schema, self.table = schema_table.split(".")
+        self.schema = schema
+        self.table = table
         conn_values = BaseHook.get_connection(conn_id)
         self.conn_type = conn_values.conn_type
         self.conn_database = conn_values.schema

--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -4,41 +4,68 @@ and MSSQL. These functions are building blocks of Operators that copy
 data following full and incremental strategies.
 """
 
-from airflow import settings
-from airflow.models import Connection
-from airflow.utils.email import send_email
+from datetime import datetime
+from typing import Dict
+
 from airflow.utils.decorators import apply_defaults
 from airflow.hooks.base import BaseHook
 
-from FastETL.custom_functions.fast_etl import copy_db_to_db
+from FastETL.custom_functions.fast_etl import copy_db_to_db, sync_db_2_db
+
 
 class DbToDbHook(BaseHook):
 
-    @apply_defaults
-    def __init__(self,
-                 source_conn_id: str,
-                 destination_conn_id: str,
-                 *args,
-                 **kwargs):
-        self.source_conn_id = source_conn_id
-        self.destination_conn_id = destination_conn_id
+    def __init__(
+        self,
+        source: Dict[str, str],
+        destination: Dict[str, str],
+        *args,
+        **kwargs
+    ):
+        self.source = source
+        self.destination = destination
 
-    def full_copy(self,
-             destination_table: str,
-             select_sql: str = None,
-             columns_to_ignore: list = [],
-             destination_truncate: str = True,
-             source_table: str = None,
-             chunksize: int = 1000,
-             copy_table_comments: bool = False):
+    def full_copy(
+        self,
+        columns_to_ignore: list = None,
+        destination_truncate: str = True,
+        chunksize: int = 1000,
+        copy_table_comments: bool = False,
+    ):
         copy_db_to_db(
-            source_table=source_table,
-            destination_table=destination_table,
-            source_conn_id=self.source_conn_id,
-            destination_conn_id=self.destination_conn_id,
-            select_sql=select_sql,
+            source=self.source,
+            destination=self.destination,
             columns_to_ignore=columns_to_ignore,
             destination_truncate=destination_truncate,
             chunksize=chunksize,
-            copy_table_comments=copy_table_comments
-            )
+            copy_table_comments=copy_table_comments,
+        )
+
+    def incremental_copy(
+        self,
+        table: str,
+        date_column: str,
+        key_column: str,
+        since_datetime: datetime = None,
+        sync_exclusions: bool = False,
+        chunksize: int = 1000,
+        copy_table_comments: bool = False,
+    ):
+        sync_db_2_db(
+            source_conn_id=self.source.conn_id,
+            destination_conn_id=self.destination.conn_id,
+            source_schema=self.source.schema,
+            source_exc_schema=self.source.get("source_exc_schema", None),
+            source_exc_table=self.source.get("source_exc_table", None),
+            source_exc_column=self.source.get("source_exc_column", None),
+            select_sql=self.source.get("query", None),
+            destination_schema=self.destination.schema,
+            increment_schema=self.destination.get("increment_schema", None),
+            table=table,
+            date_column=date_column,
+            key_column=key_column,
+            since_datetime=since_datetime,
+            sync_exclusions=sync_exclusions,
+            chunksize=chunksize,
+            copy_table_comments=copy_table_comments,
+        )

--- a/hooks/db_to_db_hook.py
+++ b/hooks/db_to_db_hook.py
@@ -7,7 +7,6 @@ data following full and incremental strategies.
 from datetime import datetime
 from typing import Dict
 
-from airflow.utils.decorators import apply_defaults
 from airflow.hooks.base import BaseHook
 
 from FastETL.custom_functions.fast_etl import copy_db_to_db, sync_db_2_db

--- a/operators/copy_db_to_db_operator.py
+++ b/operators/copy_db_to_db_operator.py
@@ -14,50 +14,65 @@ Args:
     source_table será ignorado
 """
 
+from datetime import datetime
+from typing import Dict
+
 from airflow.models.baseoperator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 from FastETL.hooks.db_to_db_hook import DbToDbHook
 
 class CopyDbToDbOperator(BaseOperator):
-    template_fields = ('select_sql', )
 
-    @apply_defaults
     def __init__(
             self,
-            destination_table: str,
-            source_conn_id: str,
-            destination_conn_id: str,
-            source_table: str = None,
-            select_sql: str = None,
-            columns_to_ignore: list = [],
+            source: Dict[str, str],
+            destination: Dict[str, str],
+            columns_to_ignore: list = None,
             destination_truncate: bool = True,
             chunksize: int = 1000,
             copy_table_comments: bool = False,
+            is_incremental: bool = False,
+            table: str = None,
+            date_column: str = None,
+            key_column: str = None,
+            since_datetime: datetime = None,
+            sync_exclusions: bool = False,
             *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.destination_table = destination_table
-        self.source_conn_id = source_conn_id
-        self.destination_conn_id = destination_conn_id
-        self.source_table = source_table
-        self.select_sql = select_sql
+        self.source = source
+        self.destination = destination
         self.columns_to_ignore = columns_to_ignore
         self.destination_truncate = destination_truncate
         self.chunksize = chunksize
         self.copy_table_comments = copy_table_comments
-
+        self.is_incremental=is_incremental
+        self.table=table
+        self.date_column=date_column
+        self.key_column=key_column
+        self.since_datetime=since_datetime
+        self.sync_exclusions=sync_exclusions
 
     def execute(self, context):
         hook = DbToDbHook(
-            source_conn_id=self.source_conn_id,
-            destination_conn_id=self.destination_conn_id,
+            source=self.source,
+            destination=self.destination,
             )
-        hook.full_copy(
-            destination_table=self.destination_table,
-            source_table=self.source_table,
-            select_sql=self.select_sql,
-            columns_to_ignore=self.columns_to_ignore,
-            destination_truncate=self.destination_truncate,
-            chunksize=self.chunksize,
-            copy_table_comments=self.copy_table_comments
+
+        if self.is_incremental:
+            hook.incremental_copy(
+                table=self.table,
+                date_column=self.date_column,
+                key_column=self.key_column,
+                since_datetime=self.since_datetime,
+                sync_exclusions=self.sync_exclusions,
+                chunksize=self.chunksize,
+                copy_table_comments=self.copy_table_comments,
+            )
+        else:
+            hook.full_copy(
+                columns_to_ignore=self.columns_to_ignore,
+                destination_truncate=self.destination_truncate,
+                chunksize=self.chunksize,
+                copy_table_comments=self.copy_table_comments
             )

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -21,8 +21,14 @@ with DAG(
         for dest_conf in db_confs:
             CopyDbToDbOperator(
                 task_id=f'test_from_{source_conf[0]}_to_{dest_conf[0]}',
-                source_table=f'{source_conf[1]}.source_table',
-                destination_table=f'{dest_conf[1]}.destination_table',
-                source_conn_id=f'{source_conf[0]}-source-conn',
-                destination_conn_id=f'{dest_conf[0]}-destination-conn',
-                )
+                source={
+                    "conn_id": f'{source_conf[0]}-source-conn',
+                    "schema": source_conf[1],
+                    "table": 'source_table',
+                },
+                destination={
+                    "conn_id": f'{dest_conf[0]}-destination-conn',
+                    "schema": dest_conf[1],
+                    "table": 'destination_table',
+                },
+            )


### PR DESCRIPTION
Changes CopyDbToDb parameters. `conn_id`, `table` and `select_sql` parameters adapted for a dictionary variable. `table` parameter was expected as `schema.table`, now the dictionary has the keys `schema`, `table` and previous source or destination connection info. Additionally, the function `sync_db_2_db` now can be called from airflow CopyDbToDbOperator with the flag `is_incremental` set to `true`.