### PR TITLE
Add DocumentTemplateToDataDictionaryOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change log
+
+Here are only the breaking and most significant changes. For a full
+account of changes, please see the [commit history](commits/main).
+
+## 0.0.4
+
+* Added the tabular data package's title and description to the top of
+  the data dictionary file created by
+  `TabularDataPackageToDataDictionaryOperator`.
+* Added a `DocumentTemplateToDataDictionaryOperator` that allows for
+  creating a data dictionary from an ODT document template and a tabular
+  data package.

--- a/fastetl/operators/datapackage_to_datadictionary_operator.py
+++ b/fastetl/operators/datapackage_to_datadictionary_operator.py
@@ -6,9 +6,14 @@ descriptor containing table schema.
 from typing import Sequence
 import logging
 
+from frictionless import Package
+
 from airflow.models.baseoperator import BaseOperator
 
-from fastetl.custom_functions.utils.odf_tables import create_data_dictionary
+from fastetl.custom_functions.utils.odf_tables import (
+    create_data_dictionary,
+    create_data_dictionary_from_template,
+)
 
 
 class TabularDataPackageToDataDictionaryOperator(BaseOperator):
@@ -24,12 +29,18 @@ class TabularDataPackageToDataDictionaryOperator(BaseOperator):
     * type
     * description
 
-    data_package (str): path to the Frictionless data package descriptor.
-    output_document (str): path to the resulting odf file.
-    lang (str): language code to use for the table column headers.
-        Defaults to "en".
+    Args:
+        data_package (str): path to the Frictionless data package descriptor.
+        output_document (str): path to the resulting odf file.
+        lang (str): language code to use for the table column headers.
+            Defaults to "en".
     """
-    template_fields: Sequence[str] = ("data_package", "output_document", "lang", )
+
+    template_fields: Sequence[str] = (
+        "data_package",
+        "output_document",
+        "lang",
+    )
     ui_color = "#efdec2"
 
     def __init__(
@@ -49,4 +60,63 @@ class TabularDataPackageToDataDictionaryOperator(BaseOperator):
         logging.info("Data package: %s", self.data_package)
         logging.info("Output document: %s", self.output_document)
         logging.info("Language: %s", self.lang)
-        create_data_dictionary(self.data_package, self.output_document, self.lang)
+        create_data_dictionary(
+            data_package=Package(self.data_package),
+            output=self.output_document,
+            lang=self.lang,
+        )
+
+
+class DocumentTemplateToDataDictionaryOperator(BaseOperator):
+    """
+    Creates a data dictionary document, in Open Document Text format,
+    by taking a document template and updating the tables that match
+    with existing resource names.
+
+    The table name in the document must match exactly with existing
+    resource names in the Tabular Data Package provided.
+
+    For the Tabular Data Package specifications, see:
+    https://specs.frictionlessdata.io/tabular-data-package/
+
+    Each table in the template must have three columns:
+    * field name
+    * type
+    * description
+
+    Args:
+        data_package (str): path to the Frictionless data package descriptor.
+        document_template(str): path to the OpenDocument format document
+            to be used as a template.
+        output_document (str): path to the resulting odf file.
+    """
+
+    template_fields: Sequence[str] = (
+        "data_package",
+        "document_template",
+        "output_document",
+    )
+    ui_color = "#e2efc2"
+
+    def __init__(
+        self,
+        data_package: str,
+        document_template: str,
+        output_document: str,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.data_package = data_package
+        self.document_template = document_template
+        self.output_document = output_document
+
+    def execute(self, context: dict):
+        """Execute the operator."""
+        logging.info("Data package: %s", self.data_package)
+        logging.info("Template document: %s", self.document_template)
+        logging.info("Output document: %s", self.output_document)
+        create_data_dictionary_from_template(
+            data_package=Package(self.data_package),
+            doc_template=self.document_template,
+            output=self.output_document,
+        )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 """Perform the package apache-airflow-providers-fastetl setup."""
 setup(

--- a/tests/test_odf_tables.py
+++ b/tests/test_odf_tables.py
@@ -84,7 +84,7 @@ def test_create_new_table_document(
 )
 def test_create_new_data_dictionary(data_package_descriptor: str):
     descriptor = yaml.safe_load(data_package_descriptor)
-    create_data_dictionary(descriptor, TEMP_DOCUMENT_NAME)
+    create_data_dictionary(Package(descriptor), TEMP_DOCUMENT_NAME)
 
     # verify contents of document file
     document = odf.opendocument.load(TEMP_DOCUMENT_NAME)


### PR DESCRIPTION
* Add the tabular data package's title and description to the top of the data dictionary file created by `TabularDataPackageToDataDictionaryOperator`.
* Add a `DocumentTemplateToDataDictionaryOperator` that allows for  creating a data dictionary from an ODT document template and a tabular  data package.
* bump version to 0.0.4