### PR TITLE
fix: add BINARY type mapping to LargeBinary in create_table_from_others

### DIFF
--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -272,6 +272,7 @@ def create_table_from_others(
         type_mapping = {
             "NUMERIC": sa_types.Numeric(38, 13),
             "BIT": sa_types.Boolean(),
+            "BINARY": sa_types.LargeBinary(),
         }
 
         if db_provider == "mssql":


### PR DESCRIPTION
Problem: Columns of type `binary(16)` in MySQL caused an `AttributeError` during the execution of `create_table_from_others` because the BINARY type was not mapped.


Solution: Added `"BINARY": sa_types.LargeBinary()` to the `type_mapping` of the `_convert_column` function.